### PR TITLE
Remove attachments name

### DIFF
--- a/src/proto/messages.proto
+++ b/src/proto/messages.proto
@@ -19,7 +19,6 @@ message CreateMessageEvent {
   string reply_to_message_id = 5; // ID of the message being replied to, if any
   message Attachment {
     string id = 1;
-    string name = 2;
     string url = 3;
   }
   repeated Attachment attachments = 6;


### PR DESCRIPTION
removing the name of the attachments since it's not relevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the attachment "name" field; attachments now include only id and url. This changes the public message attachment schema and may require client updates to handle the simplified attachment structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->